### PR TITLE
Fix Rake Problems

### DIFF
--- a/application/controllers/admin/Contents.php
+++ b/application/controllers/admin/Contents.php
@@ -77,7 +77,7 @@ class Contents extends Admin_Controller
                 $content_id = $this->content_model->insert($insert_content);
             }
 
-            $insert_translation = array('content_id'=>$content_id,'title' => $title, 'short_title' => $short_title, 'teaser' => $teaser,'content' => $content,'page_title' => $page_title, 'page_description' => $page_description,'page_keywords' => $page_keywords,'language_slug' => $language_slug);
+            $insert_translation = array('content_id'=>$content_id, 'content_type'=>$content_type',title' => $title, 'short_title' => $short_title, 'teaser' => $teaser,'content' => $content,'page_title' => $page_title, 'page_description' => $page_description,'page_keywords' => $page_keywords,'language_slug' => $language_slug);
 
             if($translation_id = $this->content_translation_model->insert($insert_translation))
             {


### PR DESCRIPTION
When performing Analyze method in Rake.php content type is searched in translations. However, the table "content_translation" hasn't got a content_type field. After adding it in DB, it was also necessary to insert content_type into the table, therefor the change in line 80.
